### PR TITLE
Add option to edit role on team list

### DIFF
--- a/add-option-to-edit-role-on-team-list.md
+++ b/add-option-to-edit-role-on-team-list.md
@@ -1,0 +1,1 @@
+Content for file add-option-to-edit-role-on-team-list.md


### PR DESCRIPTION
The UI only allows members to be added/removed. The purpose of this is to allow admins to also edit the role of each member.